### PR TITLE
Rewrite PWM detection using `lightmotif` library

### DIFF
--- a/minimotif_scripts/detection_pwm.py
+++ b/minimotif_scripts/detection_pwm.py
@@ -162,6 +162,8 @@ def write_output(results_dict, reg_name, gb_name, reg_type, outdir):
 
 
 def run_lightmotif(filename, pssm, pvalue_threshold, thresholds_pwm):
+    # compile a regular expression to parse the record headers
+    header_rx = re.compile("([^~]*)~([0-9]+):([0-9]+)~(.*)")
     # compute matrix reverse-complement
     pssm_rc = pssm.reverse_complement()
 
@@ -188,7 +190,7 @@ def run_lightmotif(filename, pssm, pvalue_threshold, thresholds_pwm):
         )
 
         # parse sequence headers
-        region, start_, end_, _ = re.search("([^~]*)~([0-9]+):([0-9]+)~(.*)", record.id).groups()
+        region, start_, end_, _ = header_rx.search(record.id).groups()
 
         # record results
         for i, strand in indices:

--- a/minimotif_scripts/detection_pwm.py
+++ b/minimotif_scripts/detection_pwm.py
@@ -190,7 +190,7 @@ def run_lightmotif(filename, pssm, pvalue_threshold, thresholds_pwm):
         )
 
         # parse sequence headers
-        region, start_, end_, _ = header_rx.search(record.id).groups()
+        region_, start_, end_, _ = header_rx.search(record.id).groups()
 
         # record results
         for i, strand in indices:
@@ -199,15 +199,15 @@ def run_lightmotif(filename, pssm, pvalue_threshold, thresholds_pwm):
             end = start + len(pssm)
             score = fwd_scores[i] if strand == "+" else bwd_scores[i]
             # get proper region coordinates
-            if region.count("-") == 1:
-                first_gene, second_gene = region.split('-')
+            if region_.count("-") == 1:
+                first_gene, second_gene = region_.split('-')
                 range_region = ((int(end_) - int(start_))/2) + int(start_)
                 if start <= range_region:
                     region = first_gene
                 else:
                     region = second_gene
             else:
-                region = region
+                region = region_
             # get sequence of binding site
             seq = record.seq[i:i+len(pssm)]
             if strand == "-":
@@ -222,9 +222,6 @@ def run_lightmotif(filename, pssm, pvalue_threshold, thresholds_pwm):
             ])
 
     return results_dict
-
-    # write output
-    write_output(results_dict, reg_name, gb_name, reg_type, outdir)
 
 
 def run_pwm_detection(genbank_file, pfm, pseudocount, reg_name, gbk_regions, coding, pvalue, batch, outdir):


### PR DESCRIPTION
Hi Hannah!

This PR contains a rewrite of the PWM scanning algorithm using `lightmotif` (you will need `v0.7.2` or later, since I added some new functionalities to the Python bindings that were missing to run this nicely). I did some comparison and it produces very slightly different results on the scores because of the change from 64-bit to 32-bit floating point precision, but that only seems to affect the scores down to the 5th decimal or so. 

Before:

<details>
<pre>
Region	Location	Strand	Score	Confidence	Sequence
b0329	346451:346467	+	21.166001285866514	medium	TGATAGTGTGATAACA
b0412	432244:432260	-	25.91778788400783	strong	TGTAAGCAGAGTAACA
b1158	1210285:1210301	-	21.16600128586652	medium	TGTTGCAATTTTATCA
b1927	2006171:2006187	+	23.281478503286458	strong	TGTTACAATGTTTTCA
b2004	2077096:2077112	-	21.16600128586652	medium	TGTAAGGATTTTATCG
b2063	2137852:2137868	-	21.16600128586652	medium	TGATCGAATTGTGACA
b4668	2153624:2153640	-	21.635234027454615	medium	TGAAGGCATACTTTCA
b2162	2255251:2255267	+	21.468291360480997	medium	TGATTGAATCTTAACA
b2441	2558717:2558733	-	21.98912352378244	medium	TCACAGCATTCTAACA
b2964	3105635:3105651	+	26.740910121923754	strong	TGATAGAATCCCATCA
b2964	3105635:3105651	-	21.166001285866514	medium	TGATAGAATCCCATCA
b3518	3669296:3669312	-	21.16600128586652	medium	TGATAGGAATCAATCA
b3594	3768008:3768024	+	21.166001285866514	medium	GGATACAGTGCTAACA
b3740	3923009:3923025	-	21.468291360480997	medium	TGTTAACAGTCTAACC
b3795	3982643:3982659	+	21.16600128586652	medium	TGTTAGTGTCCTTACG
b3866	4051204:4051220	-	21.16600128586652	medium	TGCAAGGATTGTAAGA
b4381	4617262:4617278	+	27.09479961825157	strong	TGTTAGAATACTAACA
b4381	4617262:4617278	-	28.38715459775559	strong	TGTTAGAATACTAACA
</pre>
</details>

After:
<details>
<pre>
Region	Location	Strand	Score	Confidence	Sequence
b0329	346451:346467	+	21.166004180908203	medium	TGATAGTGTGATAACA
b0412	432244:432260	-	25.917789459228516	strong	TGTTACTCTGCTTACA
b1158	1210285:1210301	-	21.166004180908203	medium	TGATAAAATTGCAACA
b1927	2006171:2006187	+	23.281478881835938	strong	TGTTACAATGTTTTCA
b2004	2077096:2077112	-	21.16600227355957	medium	CGATAAAATCCTTACA
b2063	2137852:2137868	-	21.166004180908203	medium	TGTCACAATTCGATCA
b4668	2153624:2153640	-	21.635234832763672	medium	TGAAAGTATGCCTTCA
b2162	2255251:2255267	+	21.468292236328125	medium	TGATTGAATCTTAACA
b2441	2558717:2558733	-	21.989124298095703	medium	TGTTAGAATGCTGTGA
b2964	3105635:3105651	+	26.740909576416016	strong	TGATAGAATCCCATCA
b2964	3105635:3105651	-	21.166004180908203	medium	TGATGGGATTCTATCA
b3518	3669296:3669312	-	21.166004180908203	medium	TGATTGATTCCTATCA
b3594	3768008:3768024	+	21.166004180908203	medium	GGATACAGTGCTAACA
b3740	3923009:3923025	-	21.468294143676758	medium	GGTTAGACTGTTAACA
b3795	3982643:3982659	+	21.16600227355957	medium	TGTTAGTGTCCTTACG
b3866	4051204:4051220	-	21.166004180908203	medium	TCTTACAATCCTTGCA
b4381	4617262:4617278	+	27.094799041748047	strong	TGTTAGAATACTAACA
b4381	4617262:4617278	-	28.387157440185547	strong	TGTTAGTATTCTAACA
</pre>
</details>

There's also probably a way to use PyHMMER for the `nhmmscan` part, perhaps I can have a look eventually!